### PR TITLE
Newer versions of WSClean don't require a WEIGHT_SPECTRUM column

### DIFF
--- a/Pyxides/im/wsclean.py
+++ b/Pyxides/im/wsclean.py
@@ -170,7 +170,8 @@ def make_image(msname='$MS',image_prefix='${im.BASENAME_IMAGE}',column='${im.COL
     path = argo.findImager(path,imager_name='WSCLEAN')
     
     # wsclean requires a WEIGHT_SPECTRUM column in the MS
-    argo.addcol(msname,colname='WEIGHT_SPECTRUM',valuetype='float',init_with=1) 
+    if wsclean_version()[0]<1.6:
+        argo.addcol(msname,colname='WEIGHT_SPECTRUM',valuetype='float',init_with=1) 
     
     if 'datacolumn' not in kw.keys():
         kw['datacolumn'] = column


### PR DESCRIPTION
Only add this column for versions <=1.5