### PR TITLE
replace CASA importfits() with pyrap.images

### DIFF
--- a/Pyxides/im/argo.py
+++ b/Pyxides/im/argo.py
@@ -14,6 +14,7 @@ import std
 import glob
 import time
 import Owlcat.FitsTool as fitstool
+import pyrap.images as images
 
 # Load some Pyxis functionality
 from Pyxis.ModSupport import *
@@ -30,8 +31,9 @@ def fits2casa (input,output):
         rm_fr(output)
     if not exists(input):
         abort("$input does not exist")
-    std.runcasapy("importfits('$input','$output',overwrite=True)")
-#    x.imagecalc("in='$input'","out=$output",split_args=False)
+    image = images.image(input)
+    image.saveas(output,overwrite=True)
+
 
 def make_threshold_mask (input="${im.RESTORED_IMAGE}",threshold=0,output="$im.MASK_IMAGE",high=1,low=0):
     """


### PR DESCRIPTION
Realised I needed CASA to create a docker container to predict visibilities from a FITS image. Using pyrap.images is simpler, and avoids a needless CASA dependence. 