### PR TITLE
Multiple commands to the run function

### DIFF
--- a/Pyxides/mqt.py
+++ b/Pyxides/mqt.py
@@ -52,9 +52,15 @@ def run (script="$SCRIPT",job="$JOB",config="$TDLCONFIG",section="$SECTION",save
       args = [ "--mt $MULTITHREAD" ] + args
   if saveconfig:
       args = [ "--save-config $saveconfig"  ] + args
-  args += [ "%s=%s"%(a,b) for a,b in options.iteritems() ] + \
-      [ "$EXTRA_TDLOPTS $script =$job" ];
-  # run pipeliner
+  if isinstance(options, list):
+    for dictionary in options:
+      args += [ "%s=%s"%(a,b) for a,b in dictionary.iteritems() ] + \
+          [ "$EXTRA_TDLOPTS $script =$job "]
+  else:
+    args += [ "%s=%s"%(a,b) for a,b in options.iteritems() ] + \
+        [ "$EXTRA_TDLOPTS $script =$job" ]; 
+
+ # run pipeliner
   if MEMPROF:
     args.append("--memprof");
     pipeliner_mprof(*args);
@@ -72,3 +78,4 @@ def msrun (script="$SCRIPT",job="$JOB",config="$TDLCONFIG",section="$SECTION",ar
     options=options); 
 
 document_globals(msrun,"MULTITHREAD EXTRA_TDLOPTS SCRIPT JOB SECTION TDLCONFIG");
+


### PR DESCRIPTION
This was a feature I've been using for a while. It allows multiple commands to be passed to the meqserver at once. This was needed to avoid having to restart the meqserver between commands.

The second commit 'cleaning up' is just because I had to pull some new changes and recommit them. 